### PR TITLE
Add extra dnf and apt dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ yarn install
 dnf install python-devel openldap-devel
 ```
 
+#### If running locally on Ubuntu...
+```
+sudo apt-get install libsasl2-dev python-dev libldap2-dev libssl-dev
+```
+
 ## Credits
 
 Credit to [ComputerScienceHouse/conditional](https://github.com/ComputerScienceHouse/conditional) the pylint and gulp reference

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ npm install -g gulp
 yarn install
 ```
 
+#### If running locally on Fedora...
+```
+dnf install python-devel openldap-devel
+```
+
 ## Credits
 
 Credit to [ComputerScienceHouse/conditional](https://github.com/ComputerScienceHouse/conditional) the pylint and gulp reference


### PR DESCRIPTION
You have to install `openldap-devel` to be able to install python-ldap